### PR TITLE
Add GITHUB_TOKEN to build job

### DIFF
--- a/.github/workflows/create-tag-on-master-branch.yaml
+++ b/.github/workflows/create-tag-on-master-branch.yaml
@@ -16,6 +16,8 @@ jobs:
     name: Build maven project
 #    if: endsWith(github.event.base_ref, 'main') == true
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Use GITHUB_TOKEN during maven build so that the shared libraries can get from GitHub Packages